### PR TITLE
Improve layout performance

### DIFF
--- a/app/src/main/kotlin/ca/allanwang/gitdroid/StartActivity.kt
+++ b/app/src/main/kotlin/ca/allanwang/gitdroid/StartActivity.kt
@@ -3,6 +3,7 @@ package ca.allanwang.gitdroid
 import android.os.Bundle
 import ca.allanwang.gitdroid.activity.IssueCommentActivity
 import ca.allanwang.gitdroid.activity.LoginActivity
+import ca.allanwang.gitdroid.activity.MainActivity
 import ca.allanwang.gitdroid.activity.RepoActivity
 import ca.allanwang.gitdroid.activity.base.BaseActivity
 import ca.allanwang.gitdroid.data.GitNameAndOwner
@@ -15,8 +16,8 @@ class StartActivity : BaseActivity() {
         when {
             prefs.token.isBlank() -> startActivity<LoginActivity>()
 //            else -> startActivity<BlobActivity>()
-//            else -> startActivity<MainActivity>()
-            else -> repoActivityTest()
+            else -> startActivity<MainActivity>()
+//            else -> repoActivityTest()
         }
     }
 

--- a/app/src/main/kotlin/ca/allanwang/gitdroid/activity/MainActivity.kt
+++ b/app/src/main/kotlin/ca/allanwang/gitdroid/activity/MainActivity.kt
@@ -48,7 +48,6 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
         )
         drawerLayout.addDrawerListener(toggle)
         toggle.syncState()
-
         navView.setNavigationItemSelectedListener(this@MainActivity)
     }
 

--- a/app/src/main/kotlin/ca/allanwang/gitdroid/activity/RepoActivity.kt
+++ b/app/src/main/kotlin/ca/allanwang/gitdroid/activity/RepoActivity.kt
@@ -181,7 +181,7 @@ class RepoActivity : ToolbarActivity<ViewRepoFilesBinding>() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.action_branch -> loadRefs()
+//            R.id.action_branch -> loadRefs()
             else -> return super.onOptionsItemSelected(item)
         }
         return true

--- a/app/src/main/kotlin/ca/allanwang/gitdroid/activity/base/BaseActivity.kt
+++ b/app/src/main/kotlin/ca/allanwang/gitdroid/activity/base/BaseActivity.kt
@@ -2,6 +2,7 @@ package ca.allanwang.gitdroid.activity.base
 
 import android.content.res.ColorStateList
 import android.graphics.Color
+import android.os.Build
 import android.view.Menu
 import android.view.MenuItem
 import android.view.ViewGroup
@@ -100,7 +101,12 @@ abstract class BaseActivity : KauBaseActivity() {
     fun inflateMenu(@MenuRes menuRes: Int, menu: Menu) {
         val tintList = ColorStateList.valueOf(Color.WHITE)
         menuInflater.inflate(menuRes, menu)
-        menu.forEach { it.iconTintList = tintList }
+        // TODO tint for other versions
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            menu.forEach {
+                it.iconTintList = tintList
+            }
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/codeview/src/main/kotlin/ca/allanwang/gitdroid/codeview/recycler/CodeAdapter.kt
+++ b/codeview/src/main/kotlin/ca/allanwang/gitdroid/codeview/recycler/CodeAdapter.kt
@@ -45,7 +45,6 @@ class CodeAdapter(context: Context) : RecyclerView.Adapter<CodeViewHolder>() {
             count < 10 -> return 1
             else -> log10(count).toInt() + 1
         }
-        L.d { "Digit count $digitCount" }
         return CodeViewUtils.computeWidth(textPaint, "0".repeat(digitCount)).ceilInt()
     }
 

--- a/codeview/src/main/kotlin/ca/allanwang/gitdroid/codeview/recycler/CodeAdapter.kt
+++ b/codeview/src/main/kotlin/ca/allanwang/gitdroid/codeview/recycler/CodeAdapter.kt
@@ -117,15 +117,10 @@ class CodeAdapter(context: Context) : RecyclerView.Adapter<CodeViewHolder>() {
             codeItemLineNum.width = lineNumWidth
             codeItemLine.text = item.code
             codeItemLine.width = lineCodeWidth
-            theme?.also {
+            theme.also {
                 codeItemLineNum.setTextColor(it.lineNumTextColor)
                 codeItemLineNum.setBackgroundColor(it.lineNumBg)
                 root.setBackgroundColor(it.contentBg)
-            }
-            if (position == 0) {
-                codeItemLine.doOnNextLayout {
-                    L.d { "Measure ${codeItemLine.width} ${codeItemLine.measuredWidth}" }
-                }
             }
         }
         holder.itemView.setTag(R.id.code_view_item_data, item)

--- a/views/src/main/AndroidManifest.xml
+++ b/views/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="ca.allanwang.gitdroid.views">
 
-    <application android:supportsRtl="true" />
+    <application
+        android:supportsRtl="true"
+        android:theme="@style/Theme.GitDroid.Light" />
 </manifest>

--- a/views/src/main/kotlin/ca/allanwang/gitdroid/views/BindingAdapter.kt
+++ b/views/src/main/kotlin/ca/allanwang/gitdroid/views/BindingAdapter.kt
@@ -7,24 +7,35 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
-import ca.allanwang.kau.utils.*
+import ca.allanwang.gitdroid.views.custom.RichTextView
+import ca.allanwang.kau.utils.goneIf
+import ca.allanwang.kau.utils.invisibleIf
+import ca.allanwang.kau.utils.round
+import ca.allanwang.kau.utils.string
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
-import com.google.android.material.button.MaterialButton
 import github.type.CommentAuthorAssociation
 import java.net.URI
 import java.util.*
 
+private fun notVisible(value: Any?): Boolean = when (value) {
+    null -> true
+    is String -> value.isBlank()
+    is Boolean -> value
+    is Number -> value == 0
+    else -> false
+}
+
 @BindingAdapter("goneFlag")
 fun View.goneFlag(value: Any?) {
-    when (value) {
-        null -> gone()
-        is String -> goneIf(value.isBlank())
-        is Boolean -> goneIf(value)
-        is Number -> goneIf(value == 0)
-        else -> visible()
-    }
+    goneIf(notVisible(value))
 }
+
+@BindingAdapter("invisibleFlag")
+fun View.invisibleFlag(value: Any?) {
+    invisibleIf(notVisible(value))
+}
+
 
 @BindingAdapter("languageColor")
 fun TextView.languageColor(color: String?) {
@@ -32,7 +43,6 @@ fun TextView.languageColor(color: String?) {
     val c = ColorStateList.valueOf(Color.parseColor(color))
     compoundDrawableTintList = c
     setTextColor(c)
-    (this as? MaterialButton)?.iconTint = c
 }
 
 @BindingAdapter("relativeDateText")

--- a/views/src/main/kotlin/ca/allanwang/gitdroid/views/custom/RichTextView.kt
+++ b/views/src/main/kotlin/ca/allanwang/gitdroid/views/custom/RichTextView.kt
@@ -1,0 +1,116 @@
+package ca.allanwang.gitdroid.views.custom
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.text.TextPaint
+import android.util.AttributeSet
+import android.widget.TextView
+import androidx.core.graphics.withTranslation
+import androidx.core.view.doOnPreDraw
+import ca.allanwang.gitdroid.views.R
+
+/**
+ * TextView wrapper with helper functions for theming and aligning compound drawables
+ */
+class RichTextView @JvmOverloads constructor(
+    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : TextView(context, attrs, defStyleAttr) {
+
+    private val compoundDrawableTint: Int?
+    private val compoundDrawableSize: Int
+    private val compoundDrawableGravity: Int
+    private val compoundDrawableBounds: Rect?
+
+    init {
+        context.theme.obtainStyledAttributes(attrs, R.styleable.RichTextView, 0, 0)
+            .apply {
+                try {
+                    compoundDrawableSize = getDimensionPixelSize(R.styleable.RichTextView_compoundDrawableSize, -1)
+                    compoundDrawableTint = if (hasValue(R.styleable.RichTextView_compoundDrawableTint)) getColor(
+                        R.styleable.RichTextView_compoundDrawableTint,
+                        0
+                    ) else null
+                    compoundDrawableGravity = getInt(R.styleable.RichTextView_compoundDrawableGravity, 0)
+                    compoundDrawableBounds =
+                        if (compoundDrawableSize == -1) null else Rect(0, 0, compoundDrawableSize, compoundDrawableSize)
+                } finally {
+                    recycle()
+                }
+            }
+        // Reapply, since first application happened in parent constructor
+        // Do in post since start and end drawables don't get registered immediately
+        doOnPreDraw {
+            val drawables = compoundDrawables
+            // L.d { "NNN ${drawables.any { it != null }}" }
+            setCompoundDrawables(drawables[0], drawables[1], drawables[2], drawables[3])
+        }
+    }
+
+    private interface DrawableWrapper {
+        val drawable: Drawable
+    }
+
+    private class TopDrawable(override val drawable: Drawable, val paint: TextPaint) : Drawable(), DrawableWrapper {
+
+        override fun setAlpha(alpha: Int) {
+            drawable.alpha = alpha
+        }
+
+        override fun getOpacity(): Int {
+            return drawable.opacity
+        }
+
+        override fun setColorFilter(colorFilter: ColorFilter?) {
+            drawable.colorFilter = colorFilter
+        }
+
+        override fun getColorFilter(): ColorFilter? {
+            return drawable.colorFilter
+        }
+
+        @SuppressLint("CanvasSize")
+        override fun draw(canvas: Canvas) {
+            val lineHeight = paint.fontMetrics.bottom - paint.fontMetrics.top
+            canvas.withTranslation(y = (lineHeight - canvas.height) / 2f) {
+                drawable.draw(canvas)
+            }
+        }
+
+        override fun setBounds(bounds: Rect) {
+            super.setBounds(bounds)
+            drawable.bounds = bounds
+        }
+
+    }
+
+    private fun Drawable.orig() = if (this is DrawableWrapper) drawable else this
+    private fun Drawable.topDrawable() = this as? TopDrawable ?: TopDrawable(this, paint)
+
+    private fun update(drawable: Drawable): Drawable {
+        val d = when (compoundDrawableGravity) {
+            0 -> drawable.orig()
+            1 -> drawable.topDrawable()
+            else -> throw RuntimeException("Unknown drawable gravity flag $compoundDrawableGravity")
+        }
+        if (compoundDrawableBounds != null) {
+            d.bounds = compoundDrawableBounds
+        }
+        if (compoundDrawableTint != null) {
+            d.setTint(compoundDrawableTint)
+        }
+        return d
+    }
+
+    override fun setCompoundDrawables(left: Drawable?, top: Drawable?, right: Drawable?, bottom: Drawable?) {
+        super.setCompoundDrawables(
+            left?.let(this::update),
+            top?.let(this::update),
+            right?.let(this::update),
+            bottom?.let(this::update)
+        )
+    }
+}

--- a/views/src/main/kotlin/ca/allanwang/gitdroid/views/custom/RichTextView.kt
+++ b/views/src/main/kotlin/ca/allanwang/gitdroid/views/custom/RichTextView.kt
@@ -10,7 +10,7 @@ import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.text.TextPaint
 import android.util.AttributeSet
-import android.widget.TextView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.graphics.withTranslation
 import androidx.core.view.doOnPreDraw
 import ca.allanwang.gitdroid.views.R
@@ -20,7 +20,7 @@ import ca.allanwang.gitdroid.views.R
  */
 class RichTextView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
-) : TextView(context, attrs, defStyleAttr) {
+) : AppCompatTextView(context, attrs, defStyleAttr) {
 
     private val compoundDrawableSize: Int
     private val compoundDrawableGravity: Int

--- a/views/src/main/kotlin/ca/allanwang/gitdroid/views/custom/RichTextView.kt
+++ b/views/src/main/kotlin/ca/allanwang/gitdroid/views/custom/RichTextView.kt
@@ -42,7 +42,6 @@ class RichTextView @JvmOverloads constructor(
         // Do in post since start and end drawables don't get registered immediately
         doOnPreDraw {
             val drawables = compoundDrawables
-            // L.d { "NNN ${drawables.any { it != null }}" }
             setCompoundDrawables(drawables[0], drawables[1], drawables[2], drawables[3])
         }
     }

--- a/views/src/main/kotlin/ca/allanwang/gitdroid/views/item/Base.kt
+++ b/views/src/main/kotlin/ca/allanwang/gitdroid/views/item/Base.kt
@@ -26,14 +26,14 @@ abstract class BindingItem<Binding : ViewDataBinding>(open val data: Any?) : Abs
         get() = layoutRes
 
     override fun createView(ctx: Context, parent: ViewGroup?): View {
-        val start = System.nanoTime()
+        val start = System.currentTimeMillis()
         val binding: ViewDataBinding = DataBindingUtil.inflate(
             LayoutInflater.from(ctx),
             layoutRes, parent,
             false,
             null
         )
-        L.d { "Create view ${(System.nanoTime() - start) / 1000000}ms" }
+        L._d { "Create view ${System.currentTimeMillis() - start}ms" }
         return binding.root
     }
 

--- a/views/src/main/kotlin/ca/allanwang/gitdroid/views/item/Base.kt
+++ b/views/src/main/kotlin/ca/allanwang/gitdroid/views/item/Base.kt
@@ -11,6 +11,7 @@ import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
 import ca.allanwang.gitdroid.logger.L
 import ca.allanwang.gitdroid.views.BR
+import ca.allanwang.gitdroid.views.databinding.ViewRepoBinding
 import com.bumptech.glide.Glide
 import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.items.AbstractItem
@@ -32,7 +33,7 @@ abstract class BindingItem<Binding : ViewDataBinding>(open val data: Any?) : Abs
             false,
             null
         )
-        L.d { "Create view ${(System.nanoTime() - start) / 1000000}" }
+        L.d { "Create view ${(System.nanoTime() - start) / 1000000}ms" }
         return binding.root
     }
 

--- a/views/src/main/kotlin/ca/allanwang/gitdroid/views/item/BindingItems.kt
+++ b/views/src/main/kotlin/ca/allanwang/gitdroid/views/item/BindingItems.kt
@@ -4,6 +4,7 @@ import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.databinding.BindingAdapter
 import androidx.databinding.ViewDataBinding
+import ca.allanwang.gitdroid.data.nameAndOwner
 import ca.allanwang.gitdroid.views.*
 import ca.allanwang.gitdroid.views.databinding.*
 import com.mikepenz.fastadapter.FastAdapter
@@ -37,7 +38,7 @@ class RepoVhBinding(override val data: ShortRepoRowItem) :
     BindingItem<ViewRepoBinding>(data), BindingLayout<ViewRepoBinding> by Companion {
 
 //    override fun ViewRepoBinding.bindView(holder: ViewHolder, payloads: MutableList<Any>) {
-//        repoName.text = data.name
+//        repoName.text = data.nameAndOwner().name
 //        repoDesc.text = data.description
 //        repoDesc.goneFlag(data.description)
 //        repoStars.compactNumberText(data.stargazers.totalCount)

--- a/views/src/main/res/layout/view_issue_or_pr_item.xml
+++ b/views/src/main/res/layout/view_issue_or_pr_item.xml
@@ -92,15 +92,15 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/kau_padding_normal"
-            android:ellipsize="end"
             android:layout_marginBottom="@dimen/kau_padding_small"
+            android:ellipsize="end"
             android:lines="1"
             android:maxLines="2"
             android:text="@{model.nameWithOwner + '#' + model.number}"
             android:textColor="?android:textColorSecondary"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/ipr_v_edge"
             app:layout_constraintHorizontal_bias="0"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@id/ipr_avatar"
             app:layout_constraintTop_toBottomOf="@id/ipr_title"
             tools:text="org/repo#123" />
@@ -120,14 +120,14 @@
             app:layout_constraintTop_toTopOf="@id/ipr_login"
             app:layout_constraintVertical_bias="0.5" />
 
-        <com.google.android.material.chip.Chip
+        <ca.allanwang.gitdroid.views.custom.RichTextView
             android:id="@+id/ipr_comments"
             style="@style/SmallChipBadge"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/small_edge_margin"
             android:layout_marginEnd="@dimen/small_edge_margin"
-            app:chipIcon="@drawable/ic_chat_bubble"
+            android:drawableStart="@drawable/ic_chat_bubble"
             app:compactNumberText="@{model.commentCount}"
             app:goneFlag="@{model.commentCount}"
             app:layout_constraintBottom_toBottomOf="@id/ipr_details"

--- a/views/src/main/res/layout/view_issue_or_pr_item.xml
+++ b/views/src/main/res/layout/view_issue_or_pr_item.xml
@@ -122,7 +122,7 @@
 
         <ca.allanwang.gitdroid.views.custom.RichTextView
             android:id="@+id/ipr_comments"
-            style="@style/SmallChipBadge"
+            style="@style/SmallBadge"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/small_edge_margin"

--- a/views/src/main/res/layout/view_repo.xml
+++ b/views/src/main/res/layout/view_repo.xml
@@ -10,119 +10,111 @@
             type="github.fragment.ShortRepoRowItem" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?android:windowBackground"
         android:foreground="?selectableItemBackground"
+        android:orientation="vertical"
         android:paddingStart="@dimen/kau_activity_horizontal_margin"
         android:paddingTop="@dimen/kau_padding_small"
         android:paddingEnd="@dimen/kau_activity_horizontal_margin"
-        android:paddingBottom="@dimen/kau_padding_small"
-        tools:context=".activity.MainActivity">
+        android:paddingBottom="@dimen/kau_padding_small">
 
         <TextView
             android:id="@+id/repo_name"
             style="@style/TextAppearance.AppCompat.Medium"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@{model.fragments.repoNameAndOwner.name}"
             android:textColor="?android:textColorPrimary"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             tools:text="@tools:sample/full_names" />
 
         <TextView
             android:id="@+id/repo_desc"
             style="@style/TextAppearance.AppCompat.Caption"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:maxLines="2"
             android:text="@{model.description}"
             android:textColor="?android:textColorSecondary"
             app:goneFlag="@{model.description}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/repo_name"
             tools:text="@tools:sample/lorem/random" />
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/repo_stars"
-            style="@style/RepoChips"
-            android:layout_width="0dp"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:chipIcon="@drawable/ic_star_border"
-            app:compactNumberText="@{model.stargazers.totalCount}"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/repo_desc"
-            app:layout_constraintWidth_percent="0.12"
-            tools:text="123" />
+            android:gravity="top"
+            android:orientation="horizontal">
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/repo_forks"
-            style="@style/RepoChips"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:chipIcon="@drawable/ic_fork"
-            app:compactNumberText="@{model.forkCount}"
-            app:layout_constraintStart_toEndOf="@id/repo_stars"
-            app:layout_constraintTop_toBottomOf="@id/repo_desc"
-            app:layout_constraintWidth_percent="0.12"
-            tools:text="123" />
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/repo_issues"
-            style="@style/RepoChips"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:chipIcon="@drawable/ic_issues"
-            app:compactNumberText="@{model.issues.totalCount}"
-            app:layout_constraintStart_toEndOf="@id/repo_forks"
-            app:layout_constraintTop_toBottomOf="@id/repo_desc"
-            app:layout_constraintWidth_percent="0.12"
-            tools:text="1.5k" />
+            <ca.allanwang.gitdroid.views.custom.RichTextView
+                android:id="@+id/repo_stars"
+                style="@style/RepoChips"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.12"
+                android:drawableStart="@drawable/ic_star_border"
+                android:drawablePadding="4dp"
+                app:compactNumberText="@{model.stargazers.totalCount}"
+                tools:text="123" />
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/repo_prs"
-            style="@style/RepoChips"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:chipIcon="@drawable/ic_pull_requests"
-            app:compactNumberText="@{model.pullRequests.totalCount}"
-            app:layout_constraintStart_toEndOf="@id/repo_issues"
-            app:layout_constraintTop_toBottomOf="@id/repo_desc"
-            app:layout_constraintWidth_percent="0.12"
-            tools:text="123" />
+            <ca.allanwang.gitdroid.views.custom.RichTextView
+                android:id="@+id/repo_forks"
+                style="@style/RepoChips"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.12"
+                android:drawableStart="@drawable/ic_fork"
+                app:compactNumberText="@{model.forkCount}"
+                tools:text="123" />
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/repo_language"
-            style="@style/RepoChips"
-            android:ellipsize="end"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@{model.primaryLanguage.name}"
-            app:chipIcon="@drawable/ic_language"
-            app:languageColor="@{model.primaryLanguage.color}"
-            app:layout_constraintEnd_toStartOf="@id/repo_date"
-            app:layout_constraintStart_toEndOf="@id/repo_prs"
-            app:layout_constraintTop_toBottomOf="@id/repo_desc"
-            app:layout_constraintWidth_percent="0.25"
-            tools:text="Jupyter Notebook" />
+            <ca.allanwang.gitdroid.views.custom.RichTextView
+                android:id="@+id/repo_issues"
+                style="@style/RepoChips"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.12"
+                android:drawableStart="@drawable/ic_issues"
+                app:compactNumberText="@{model.issues.totalCount}"
+                tools:text="1.5k" />
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/repo_date"
-            style="@style/RepoChips"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:chipIcon="@drawable/ic_time"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/repo_language"
-            app:layout_constraintTop_toBottomOf="@id/repo_desc"
-            app:relativeDateText="@{model.pushedAt}"
-            app:textStartPadding="4dp"
-            tools:text="@tools:sample/date/mmddyy" />
+            <ca.allanwang.gitdroid.views.custom.RichTextView
+                android:id="@+id/repo_prs"
+                style="@style/RepoChips"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.12"
+                android:drawableStart="@drawable/ic_pull_requests"
+                app:compactNumberText="@{model.pullRequests.totalCount}"
+                tools:text="123" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <ca.allanwang.gitdroid.views.custom.RichTextView
+                android:id="@+id/repo_language"
+                style="@style/RepoChips"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.25"
+                android:drawableStart="@drawable/ic_language"
+                android:ellipsize="end"
+                android:text="@{model.primaryLanguage.name}"
+                app:languageColor="@{model.primaryLanguage.color}"
+                tools:text="Jupyter Notebook" />
+
+            <ca.allanwang.gitdroid.views.custom.RichTextView
+                android:id="@+id/repo_date"
+                style="@style/RepoChips"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.27"
+                android:drawableStart="@drawable/ic_time"
+                app:relativeDateText="@{model.pushedAt}"
+                app:textStartPadding="4dp"
+                tools:text="@tools:sample/date/mmddyy" />
+
+        </LinearLayout>
+
+
+    </LinearLayout>
 </layout>

--- a/views/src/main/res/layout/view_repo.xml
+++ b/views/src/main/res/layout/view_repo.xml
@@ -51,7 +51,7 @@
 
             <ca.allanwang.gitdroid.views.custom.RichTextView
                 android:id="@+id/repo_stars"
-                style="@style/RepoChips"
+                style="@style/RepoBadge"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.12"
@@ -62,7 +62,7 @@
 
             <ca.allanwang.gitdroid.views.custom.RichTextView
                 android:id="@+id/repo_forks"
-                style="@style/RepoChips"
+                style="@style/RepoBadge"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.12"
@@ -72,7 +72,7 @@
 
             <ca.allanwang.gitdroid.views.custom.RichTextView
                 android:id="@+id/repo_issues"
-                style="@style/RepoChips"
+                style="@style/RepoBadge"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.12"
@@ -82,7 +82,7 @@
 
             <ca.allanwang.gitdroid.views.custom.RichTextView
                 android:id="@+id/repo_prs"
-                style="@style/RepoChips"
+                style="@style/RepoBadge"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.12"
@@ -92,7 +92,7 @@
 
             <ca.allanwang.gitdroid.views.custom.RichTextView
                 android:id="@+id/repo_language"
-                style="@style/RepoChips"
+                style="@style/RepoBadge"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.25"
@@ -104,7 +104,7 @@
 
             <ca.allanwang.gitdroid.views.custom.RichTextView
                 android:id="@+id/repo_date"
-                style="@style/RepoChips"
+                style="@style/RepoBadge"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.27"

--- a/views/src/main/res/layout/view_repo.xml
+++ b/views/src/main/res/layout/view_repo.xml
@@ -99,6 +99,7 @@
                 android:drawableStart="@drawable/ic_language"
                 android:ellipsize="end"
                 android:text="@{model.primaryLanguage.name}"
+                app:invisibleFlag="@{model.primaryLanguage.name}"
                 app:languageColor="@{model.primaryLanguage.color}"
                 tools:text="Jupyter Notebook" />
 

--- a/views/src/main/res/layout/view_repo_orig.xml
+++ b/views/src/main/res/layout/view_repo_orig.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="model"
+            type="github.fragment.ShortRepoRowItem" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:windowBackground"
+        android:foreground="?selectableItemBackground"
+        android:paddingStart="@dimen/kau_activity_horizontal_margin"
+        android:paddingTop="@dimen/kau_padding_small"
+        android:paddingEnd="@dimen/kau_activity_horizontal_margin"
+        android:paddingBottom="@dimen/kau_padding_small">
+
+        <TextView
+            android:id="@+id/repo_name"
+            style="@style/TextAppearance.AppCompat.Medium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{model.fragments.repoNameAndOwner.name}"
+            android:textColor="?android:textColorPrimary"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="@tools:sample/full_names" />
+
+        <TextView
+            android:id="@+id/repo_desc"
+            style="@style/TextAppearance.AppCompat.Caption"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:text="@{model.description}"
+            android:textColor="?android:textColorSecondary"
+            app:goneFlag="@{model.description}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/repo_name"
+            tools:text="@tools:sample/lorem/random" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/repo_stars"
+            style="@style/RepoChips"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:chipIcon="@drawable/ic_star_border"
+            app:compactNumberText="@{model.stargazers.totalCount}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/repo_desc"
+            app:layout_constraintWidth_percent="0.12"
+            tools:text="123" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/repo_forks"
+            style="@style/RepoChips"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:chipIcon="@drawable/ic_fork"
+            app:compactNumberText="@{model.forkCount}"
+            app:layout_constraintStart_toEndOf="@id/repo_stars"
+            app:layout_constraintTop_toBottomOf="@id/repo_desc"
+            app:layout_constraintWidth_percent="0.12"
+            tools:text="123" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/repo_issues"
+            style="@style/RepoChips"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:chipIcon="@drawable/ic_issues"
+            app:compactNumberText="@{model.issues.totalCount}"
+            app:layout_constraintStart_toEndOf="@id/repo_forks"
+            app:layout_constraintTop_toBottomOf="@id/repo_desc"
+            app:layout_constraintWidth_percent="0.12"
+            tools:text="1.5k" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/repo_prs"
+            style="@style/RepoChips"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:chipIcon="@drawable/ic_pull_requests"
+            app:compactNumberText="@{model.pullRequests.totalCount}"
+            app:layout_constraintStart_toEndOf="@id/repo_issues"
+            app:layout_constraintTop_toBottomOf="@id/repo_desc"
+            app:layout_constraintWidth_percent="0.12"
+            tools:text="123" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/repo_language"
+            style="@style/RepoChips"
+            android:ellipsize="end"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{model.primaryLanguage.name}"
+            app:chipIcon="@drawable/ic_language"
+            app:languageColor="@{model.primaryLanguage.color}"
+            app:layout_constraintEnd_toStartOf="@id/repo_date"
+            app:layout_constraintStart_toEndOf="@id/repo_prs"
+            app:layout_constraintTop_toBottomOf="@id/repo_desc"
+            app:layout_constraintWidth_percent="0.25"
+            tools:text="Jupyter Notebook" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/repo_date"
+            style="@style/RepoChips"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:chipIcon="@drawable/ic_time"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/repo_language"
+            app:layout_constraintTop_toBottomOf="@id/repo_desc"
+            app:relativeDateText="@{model.pushedAt}"
+            app:textStartPadding="4dp"
+            tools:text="@tools:sample/date/mmddyy" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/views/src/main/res/layout/view_repo_orig.xml
+++ b/views/src/main/res/layout/view_repo_orig.xml
@@ -49,7 +49,7 @@
 
         <com.google.android.material.chip.Chip
             android:id="@+id/repo_stars"
-            style="@style/RepoChips"
+            style="@style/RepoBadge"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:chipIcon="@drawable/ic_star_border"
@@ -61,7 +61,7 @@
 
         <com.google.android.material.chip.Chip
             android:id="@+id/repo_forks"
-            style="@style/RepoChips"
+            style="@style/RepoBadge"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:chipIcon="@drawable/ic_fork"
@@ -73,7 +73,7 @@
 
         <com.google.android.material.chip.Chip
             android:id="@+id/repo_issues"
-            style="@style/RepoChips"
+            style="@style/RepoBadge"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:chipIcon="@drawable/ic_issues"
@@ -85,7 +85,7 @@
 
         <com.google.android.material.chip.Chip
             android:id="@+id/repo_prs"
-            style="@style/RepoChips"
+            style="@style/RepoBadge"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:chipIcon="@drawable/ic_pull_requests"
@@ -97,7 +97,7 @@
 
         <com.google.android.material.chip.Chip
             android:id="@+id/repo_language"
-            style="@style/RepoChips"
+            style="@style/RepoBadge"
             android:ellipsize="end"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -112,7 +112,7 @@
 
         <com.google.android.material.chip.Chip
             android:id="@+id/repo_date"
-            style="@style/RepoChips"
+            style="@style/RepoBadge"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:chipIcon="@drawable/ic_time"

--- a/views/src/main/res/values/attrs.xml
+++ b/views/src/main/res/values/attrs.xml
@@ -17,7 +17,6 @@
 
     <declare-styleable name="RichTextView">
         <attr name="compoundDrawableSize" format="dimension" />
-        <attr name="compoundDrawableTint" format="color" />
         <attr name="compoundDrawableGravity" format="enum">
             <enum name="center" value="0" />
             <enum name="top" value="1" />

--- a/views/src/main/res/values/attrs.xml
+++ b/views/src/main/res/values/attrs.xml
@@ -14,4 +14,13 @@
         <item>#239a3b</item>
         <item>#196127</item>
     </array>
+
+    <declare-styleable name="RichTextView">
+        <attr name="compoundDrawableSize" format="dimension" />
+        <attr name="compoundDrawableTint" format="color" />
+        <attr name="compoundDrawableGravity" format="enum">
+            <enum name="center" value="0" />
+            <enum name="top" value="1" />
+        </attr>
+    </declare-styleable>
 </resources>

--- a/views/src/main/res/values/styles.xml
+++ b/views/src/main/res/values/styles.xml
@@ -46,7 +46,7 @@
         <item name="cornerRadius">@dimen/login_corner_radius</item>
     </style>
 
-    <style name="SmallChipBadge">
+    <style name="SmallBadge">
         <item name="android:clickable">false</item>
         <item name="android:focusable">false</item>
         <item name="compoundDrawableSize">@dimen/small_icon_size</item>
@@ -56,7 +56,7 @@
         <item name="android:textAppearance">@style/TextAppearance.MaterialComponents.Caption</item>
     </style>
 
-    <style name="RepoChips" parent="SmallChipBadge">
+    <style name="RepoBadge" parent="SmallBadge">
         <item name="compoundDrawableGravity">top</item>
         <item name="android:layout_marginTop">@dimen/kau_padding_small</item>
         <item name="compoundDrawableTint">?android:textColorSecondary</item>

--- a/views/src/main/res/values/styles.xml
+++ b/views/src/main/res/values/styles.xml
@@ -48,23 +48,18 @@
 
     <style name="SmallChipBadge">
         <item name="android:clickable">false</item>
-        <item name="chipBackgroundColor">@android:color/transparent</item>
-        <item name="chipStartPadding">0dp</item>
-        <item name="chipEndPadding">0dp</item>
-        <item name="chipIconSize">@dimen/small_icon_size</item>
-        <item name="chipMinHeight">0dp</item>
-        <item name="android:stateListAnimator">@null</item>
-        <item name="textStartPadding">4dp</item>
-        <item name="textEndPadding">4dp</item>
-        <item name="chipIconTint">?android:textColorTertiary</item>
+        <item name="android:focusable">false</item>
+        <item name="compoundDrawableSize">@dimen/small_icon_size</item>
+        <item name="compoundDrawableTint">?android:textColorTertiary</item>
+        <item name="android:drawablePadding">@dimen/kau_spacing_micro</item>
         <item name="android:textColor">?android:textColorTertiary</item>
         <item name="android:textAppearance">@style/TextAppearance.MaterialComponents.Caption</item>
     </style>
 
     <style name="RepoChips" parent="SmallChipBadge">
+        <item name="compoundDrawableGravity">top</item>
         <item name="android:layout_marginTop">@dimen/kau_padding_small</item>
-        <item name="layout_constraintHorizontal_bias">0</item>
-        <item name="chipIconTint">?android:textColorSecondary</item>
+        <item name="compoundDrawableTint">?android:textColorSecondary</item>
         <item name="android:textColor">?android:textColorSecondary</item>
     </style>
 

--- a/views/src/main/res/values/styles.xml
+++ b/views/src/main/res/values/styles.xml
@@ -50,7 +50,7 @@
         <item name="android:clickable">false</item>
         <item name="android:focusable">false</item>
         <item name="compoundDrawableSize">@dimen/small_icon_size</item>
-        <item name="compoundDrawableTint">?android:textColorTertiary</item>
+        <item name="android:drawableTint">?android:textColorTertiary</item>
         <item name="android:drawablePadding">@dimen/kau_spacing_micro</item>
         <item name="android:textColor">?android:textColorTertiary</item>
         <item name="android:textAppearance">@style/TextAppearance.MaterialComponents.Caption</item>
@@ -59,7 +59,7 @@
     <style name="RepoBadge" parent="SmallBadge">
         <item name="compoundDrawableGravity">top</item>
         <item name="android:layout_marginTop">@dimen/kau_padding_small</item>
-        <item name="compoundDrawableTint">?android:textColorSecondary</item>
+        <item name="android:drawableTint">?android:textColorSecondary</item>
         <item name="android:textColor">?android:textColorSecondary</item>
     </style>
 


### PR DESCRIPTION
Resolves #13

Before this, viewholder creation for the main repo feed took 100+ms on first run, then times from 60ms down to around 30ms. This resulted in very noticeable lag.

Originally, I thought the culprit was `DataBindingUtils`, as I have never used it before.
However, after closer inspection, it appears that material chips was the problem.
The main use case was to have icons that can be configured, so I created `RichTextView` to do the same. The added benefit is that we no longer have chip's restrictions, such as having exactly one line, allowing for better display options too.

Loading went down to around 30ms-10ms after warm up.

---

Relevant stack overflow question:

https://stackoverflow.com/questions/56746436/data-binding-inflation-is-very-slow/56765954#56765954